### PR TITLE
Fixed C API calls for ChunkedArray

### DIFF
--- a/include/nanobind_pyarrow/chunked_array.h
+++ b/include/nanobind_pyarrow/chunked_array.h
@@ -12,7 +12,20 @@
 #include <memory>
 #include <arrow/chunked_array.h>
 
+#if NANOBIND_PYARROW_USE_C_API
+#include <nanobind_pyarrow/detail/capi_stream_caster.h>
+namespace {
+    using ChunkedArrayCaster = nanobind::detail::pyarrow::pyarrow_c_api_stream_caster<arrow::ChunkedArray>;
+}
+#else
 #include <nanobind_pyarrow/detail/caster.h>
+
+namespace {
+    using ChunkedArrayCaster = nanobind::detail::pyarrow::pyarrow_caster<arrow::ChunkedArray,
+            arrow::py::is_chunked_array, arrow::py::wrap_chunked_array, arrow::py::unwrap_chunked_array>;
+}
+#endif
+
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
@@ -22,9 +35,7 @@ struct pyarrow::pyarrow_caster_name_trait<arrow::ChunkedArray> {
     static constexpr auto Name = const_name("ChunkedArray");
 };
 template<>
-struct type_caster<std::shared_ptr<arrow::ChunkedArray>>
-    : pyarrow::pyarrow_caster<arrow::ChunkedArray, arrow::py::is_chunked_array, arrow::py::wrap_chunked_array,
-              arrow::py::unwrap_chunked_array> {};
+struct type_caster<std::shared_ptr<arrow::ChunkedArray>> : ChunkedArrayCaster {};
 
 
 NAMESPACE_END(detail)

--- a/include/nanobind_pyarrow/detail/capi_stream_caster.h
+++ b/include/nanobind_pyarrow/detail/capi_stream_caster.h
@@ -101,7 +101,7 @@ struct pyarrow_c_api_stream_caster {
         }
         else if constexpr (std::is_same_v<T, arrow::ChunkedArray>)
         {
-            status = arrow::ExportChunkedArray(*src, c_stream.get());
+            status = arrow::ExportChunkedArray(src, c_stream.get());
         }
         if (!status.ok())
         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,11 +68,13 @@ function(add_extension extension_name)
 
   target_link_libraries(${extension_target} PRIVATE Nanobind_Pyarrow_warnings Nanobind_Pyarrow_options
                                                     nanobind_pyarrow::nanobind_pyarrow)
-  target_link_system_libraries(
-    ${extension_target}
-    PRIVATE
-    ${NANOBIND_TARGET}
-    nanobind_pyarrow::pyarrow)
+  target_link_system_libraries(${extension_target} PRIVATE ${NANOBIND_TARGET})
+
+  if(EXT_USE_C_API)
+    target_link_system_libraries(${extension_target} PRIVATE arrow::arrow)
+  else()
+    target_link_system_libraries(${extension_target} PRIVATE nanobind_pyarrow::pyarrow)
+  endif()
 
   nanobind_add_stub(
     ${extension_target}_stub


### PR DESCRIPTION
Use only arrow::arrow target when building test extension only with C API